### PR TITLE
fix: centralize template folder path in config

### DIFF
--- a/tp/app.py
+++ b/tp/app.py
@@ -9,6 +9,7 @@ import typer
 from tp import __version__
 from tp.config import (
     CONFIG_FILE,
+    PRINT_TEMPLATE_FOLDER,
     get_chars_per_line,
     get_check_for_updates,
     get_enable_special_letters,
@@ -79,7 +80,7 @@ def print_template(template_name: str = typer.Argument(None)) -> None:
     """
     Print using a specified template.
     """
-    template_manager = TemplateManager("tp/print_templates")
+    template_manager = TemplateManager(PRINT_TEMPLATE_FOLDER)
     if not template_name:
         typer.echo("Available templates:")
         for name in template_manager.list_templates():

--- a/tp/config.py
+++ b/tp/config.py
@@ -1,6 +1,9 @@
 import configparser
+import os
 
 CONFIG_FILE = "tp_config.ini"
+
+PRINT_TEMPLATE_FOLDER = os.path.join(os.path.dirname(os.path.realpath(__file__)), "print_templates")
 
 
 def get_printer_ip() -> str:

--- a/tp/gui.py
+++ b/tp/gui.py
@@ -17,6 +17,7 @@ from PyQt6.QtWidgets import (
 )
 
 from tp.config import (
+    PRINT_TEMPLATE_FOLDER,
     get_chars_per_line,
     get_check_for_updates,
     get_enable_special_letters,
@@ -36,7 +37,7 @@ logger = logging.getLogger(__name__)
 class MainWindow(QWidget):
     def __init__(self) -> None:
         super().__init__()
-        self.template_manager = TemplateManager("tp/print_templates")
+        self.template_manager = TemplateManager(PRINT_TEMPLATE_FOLDER)
         self.setWindowTitle("Thermal Printer Application")
         self.init_ui()
 

--- a/tp/web_app.py
+++ b/tp/web_app.py
@@ -6,6 +6,7 @@ from waitress import serve
 from werkzeug.wrappers import Response
 
 from tp.config import (
+    PRINT_TEMPLATE_FOLDER,
     get_chars_per_line,
     get_check_for_updates,
     get_enable_special_letters,
@@ -25,7 +26,7 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 app.secret_key = get_flask_secret_key()
 
-template_manager = TemplateManager("tp/print_templates")
+template_manager = TemplateManager(PRINT_TEMPLATE_FOLDER)
 
 
 @app.route("/")


### PR DESCRIPTION
Move the print templates folder path definition to a constant in the config module. Update usages of TemplateManager to use the centralized path. This improves maintainability by keeping the print template path configuration in one place.